### PR TITLE
Fixed syntax for CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@navikt/pus
+*     @navikt/pus


### PR DESCRIPTION
A `CODEOWNERS` file follows the same rules used in gitignore files — each line begins with a path. The pattern is followed by one or more GitHub usernames or team names